### PR TITLE
Update demo code and wrap an error

### DIFF
--- a/demo/nomad/client-1.hcl
+++ b/demo/nomad/client-1.hcl
@@ -16,7 +16,7 @@ ports {
   serf = 5658
 }
 
-plugin "ecs" {
+plugin "nomad-driver-ecs" {
   config {
     enabled = true
     cluster = "nomad-remote-driver-demo"

--- a/demo/nomad/client-2.hcl
+++ b/demo/nomad/client-2.hcl
@@ -14,7 +14,7 @@ ports {
   http = 6656
 }
 
-plugin "ecs" {
+plugin "nomad-driver-ecs" {
   config {
     enabled = true
     cluster = "nomad-remote-driver-demo"

--- a/ecs/ecs.go
+++ b/ecs/ecs.go
@@ -78,7 +78,7 @@ func (c awsEcsClient) RunTask(ctx context.Context, cfg TaskConfig) (string, erro
 	input := c.buildTaskInput(cfg)
 
 	if err := input.Validate(); err != nil {
-		return "", nil
+		return "", fmt.Errorf("failed to validate: %w", err)
 	}
 
 	resp, err := c.ecsClient.RunTaskRequest(input).Send(ctx)


### PR DESCRIPTION
Agent configs need to reference the plugin binary name, not the short name emitted by the plugins fingerprinting code.

Wrap an error just for clarity.