### PR TITLE
Add pkg to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,8 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# Release binary output directory
+pkg/
+
 # Dependency directories (remove the comment below to include it)
 # vendor/


### PR DESCRIPTION
The release process places the output binaries in the `pkg` folder. Without ignoring this path the release will fail because `git status` won't be clean.