### PR TITLE
Use the actual configuration value for AssignPublicIP instead of ENABLED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## UNRELEASED
+
+BUG FIXES:
+
+* config: Create ECS task with the the value for `assign_public_ip` as specified in the job [[GH-11](https://github.com/hashicorp/nomad-driver-ecs/pull/11)]
+
 ## 0.1.0 (May 12, 2021)
 
 * Initial Nomad AWS ECS Driver release for Nomad v1.1.0

--- a/ecs/ecs.go
+++ b/ecs/ecs.go
@@ -112,7 +112,7 @@ func (c awsEcsClient) buildTaskInput(cfg TaskConfig) *ecs.RunTaskInput {
 
 	// Handle the task networking setup.
 	if cfg.Task.NetworkConfiguration.TaskAWSVPCConfiguration.AssignPublicIP != "" {
-		input.NetworkConfiguration.AwsvpcConfiguration.AssignPublicIp = "ENABLED"
+		input.NetworkConfiguration.AwsvpcConfiguration.AssignPublicIp = cfg.Task.NetworkConfiguration.TaskAWSVPCConfiguration.AssignPublicIP
 	}
 	if len(cfg.Task.NetworkConfiguration.TaskAWSVPCConfiguration.SecurityGroups) > 0 {
 		input.NetworkConfiguration.AwsvpcConfiguration.SecurityGroups = cfg.Task.NetworkConfiguration.TaskAWSVPCConfiguration.SecurityGroups

--- a/ecs/ecs.go
+++ b/ecs/ecs.go
@@ -112,7 +112,12 @@ func (c awsEcsClient) buildTaskInput(cfg TaskConfig) *ecs.RunTaskInput {
 
 	// Handle the task networking setup.
 	if cfg.Task.NetworkConfiguration.TaskAWSVPCConfiguration.AssignPublicIP != "" {
-		input.NetworkConfiguration.AwsvpcConfiguration.AssignPublicIp = cfg.Task.NetworkConfiguration.TaskAWSVPCConfiguration.AssignPublicIP
+		assignPublicIp := cfg.Task.NetworkConfiguration.TaskAWSVPCConfiguration.AssignPublicIP
+		if assignPublicIp == "ENABLED" {
+			input.NetworkConfiguration.AwsvpcConfiguration.AssignPublicIp = ecs.AssignPublicIpEnabled
+		} else if assignPublicIp == "DISABLED" {
+			input.NetworkConfiguration.AwsvpcConfiguration.AssignPublicIp = ecs.AssignPublicIpDisabled
+		}
 	}
 	if len(cfg.Task.NetworkConfiguration.TaskAWSVPCConfiguration.SecurityGroups) > 0 {
 		input.NetworkConfiguration.AwsvpcConfiguration.SecurityGroups = cfg.Task.NetworkConfiguration.TaskAWSVPCConfiguration.SecurityGroups


### PR DESCRIPTION
When parsing the task network configuration, the value of AssignPublicIP is checked, but not actually used, instead it is always set to "ENABLED" if the configured value is != "". This is may be intended behaviour, but if so it is somewhat surprising and should be documented.